### PR TITLE
feat(examples): add adapter examples for PostgreSQL, MongoDB, MySQL, Redis, Cloudflare D1, and Deno KV

### DIFF
--- a/examples/cloudflare-d1-demo/README.md
+++ b/examples/cloudflare-d1-demo/README.md
@@ -1,0 +1,127 @@
+# NebulaDB Cloudflare D1 Adapter Demo
+
+This example demonstrates using NebulaDB with the Cloudflare D1 adapter inside a Cloudflare Worker. D1 is Cloudflare's edge-native SQLite database.
+
+> **Note:** Cloudflare D1 only runs inside a Cloudflare Worker environment. This example cannot be run with `node` locally — use `wrangler dev` for local simulation or `wrangler deploy` for production.
+
+## Features Demonstrated
+
+1. **D1 Binding** - Receiving the D1 instance from the Worker's `env.DB`
+2. **CRUD via HTTP** - Each route demonstrates an operation (insert, find, update, delete)
+3. **Edge Storage** - Data persists in D1 across Worker requests
+4. **Auto Table Creation** - Tables are created automatically on first save
+
+## Requirements
+
+- [Cloudflare account](https://dash.cloudflare.com/sign-up) (free tier works)
+- [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/) v3+
+- Node.js v18 or higher
+
+## Setup
+
+### 1. Install Wrangler
+
+```bash
+npm install -g wrangler
+wrangler login
+```
+
+### 2. Create a D1 Database
+
+```bash
+wrangler d1 create nebula-demo
+```
+
+Copy the `database_id` from the output and paste it into `wrangler.toml`:
+
+```toml
+[[d1_databases]]
+binding = "DB"
+database_name = "nebula-demo"
+database_id = "YOUR_D1_DATABASE_ID"   # <-- replace this
+```
+
+### 3. Install Dependencies
+
+```bash
+cd examples/cloudflare-d1-demo
+npm install
+```
+
+## Running the Demo
+
+### Local simulation
+
+```bash
+npm run dev
+```
+
+Worker runs at `http://localhost:8787`
+
+### Production deploy
+
+```bash
+npm run deploy
+```
+
+## API Routes
+
+| Method | Route | Description |
+|--------|-------|-------------|
+| GET | `/` | List all available routes |
+| POST | `/seed` | Insert 3 sample tasks |
+| GET | `/tasks` | Fetch all tasks |
+| GET | `/tasks/pending` | Fetch pending tasks |
+| PATCH | `/tasks/complete` | Complete medium priority tasks |
+| DELETE | `/tasks/done` | Remove completed tasks |
+
+### Example requests
+
+```bash
+# Seed data
+curl -X POST http://localhost:8787/seed
+
+# Fetch all tasks
+curl http://localhost:8787/tasks
+
+# Fetch pending tasks
+curl http://localhost:8787/tasks/pending
+
+# Complete a task
+curl -X PATCH http://localhost:8787/tasks/complete
+
+# Delete completed tasks
+curl -X DELETE http://localhost:8787/tasks/done
+```
+
+## Code Explanation
+
+### Adapter Setup inside a Worker
+
+```javascript
+export default {
+  async fetch(request, env) {
+    // env.DB is the D1 binding from wrangler.toml
+    const adapter = createCloudflareD1Adapter(env.DB);
+    const db = createDb({ adapter });
+  }
+};
+```
+
+### Collection with Schema
+
+```javascript
+const tasks = db.collection('tasks', {
+  schema: {
+    title: { type: 'string' },
+    priority: { type: 'string' },
+    done: { type: 'boolean' }
+  }
+});
+```
+
+## Next Steps
+
+- Try the [Deno KV demo](../deno-kv-demo) for another edge storage option
+- Explore the [NebulaDB docs](https://github.com/Nom-nom-hub/NebulaDB)
+- Read the [Cloudflare D1 docs](https://developers.cloudflare.com/d1/)

--- a/examples/cloudflare-d1-demo/package.json
+++ b/examples/cloudflare-d1-demo/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "nebula-cloudflare-d1-demo",
+  "version": "0.1.0",
+  "description": "Cloudflare D1 adapter demo for NebulaDB",
+  "main": "src/index.js",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "dependencies": {
+    "@nebula-db/core": "^0.4.0",
+    "@nebula-db/adapter-cloudflare-d1": "^0.4.1"
+  },
+  "devDependencies": {
+    "wrangler": "^3.0.0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/examples/cloudflare-d1-demo/src/index.js
+++ b/examples/cloudflare-d1-demo/src/index.js
@@ -1,0 +1,71 @@
+import { createDb } from '@nebula-db/core';
+import { createCloudflareD1Adapter } from '@nebula-db/adapter-cloudflare-d1';
+
+export default {
+  async fetch(request, env) {
+    // env.DB is the D1 binding defined in wrangler.toml
+    const adapter = createCloudflareD1Adapter(env.DB);
+    const db = createDb({ adapter });
+
+    const tasks = db.collection('tasks', {
+      schema: {
+        id: { type: 'string', optional: true },
+        title: { type: 'string' },
+        priority: { type: 'string' },
+        done: { type: 'boolean' }
+      }
+    });
+
+    try {
+      const url = new URL(request.url);
+
+      // POST /seed — insert sample data
+      if (request.method === 'POST' && url.pathname === '/seed') {
+        await tasks.insert({ title: 'Set up Cloudflare Worker', priority: 'high', done: true });
+        await tasks.insert({ title: 'Connect D1 database', priority: 'high', done: true });
+        await tasks.insert({ title: 'Deploy to production', priority: 'medium', done: false });
+        return Response.json({ message: '3 tasks seeded successfully' });
+      }
+
+      // GET /tasks — return all tasks
+      if (request.method === 'GET' && url.pathname === '/tasks') {
+        const all = await tasks.find();
+        return Response.json({ count: all.length, tasks: all });
+      }
+
+      // GET /tasks/pending — return pending tasks
+      if (request.method === 'GET' && url.pathname === '/tasks/pending') {
+        const pending = await tasks.find({ done: false });
+        return Response.json({ count: pending.length, tasks: pending });
+      }
+
+      // PATCH /tasks/complete — mark high priority tasks as done
+      if (request.method === 'PATCH' && url.pathname === '/tasks/complete') {
+        await tasks.update({ priority: 'medium', done: false }, { $set: { done: true } });
+        const updated = await tasks.findOne({ priority: 'medium' });
+        return Response.json({ message: 'Task completed', task: updated });
+      }
+
+      // DELETE /tasks/done — remove completed tasks
+      if (request.method === 'DELETE' && url.pathname === '/tasks/done') {
+        await tasks.delete({ done: true });
+        const remaining = await tasks.find();
+        return Response.json({ message: 'Completed tasks removed', remaining });
+      }
+
+      return Response.json({
+        message: 'NebulaDB Cloudflare D1 Demo',
+        routes: {
+          'POST /seed': 'Insert sample tasks',
+          'GET /tasks': 'Fetch all tasks',
+          'GET /tasks/pending': 'Fetch pending tasks',
+          'PATCH /tasks/complete': 'Complete medium priority tasks',
+          'DELETE /tasks/done': 'Delete completed tasks'
+        }
+      });
+
+    } catch (error) {
+      return Response.json({ error: error.message }, { status: 500 });
+    }
+  }
+};

--- a/examples/cloudflare-d1-demo/wrangler.toml
+++ b/examples/cloudflare-d1-demo/wrangler.toml
@@ -1,0 +1,8 @@
+name = "nebula-d1-demo"
+main = "src/index.js"
+compatibility_date = "2024-01-01"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "nebula-demo"
+database_id = "YOUR_D1_DATABASE_ID"

--- a/examples/deno-kv-demo/README.md
+++ b/examples/deno-kv-demo/README.md
@@ -1,0 +1,134 @@
+# NebulaDB Deno KV Adapter Demo
+
+This example demonstrates using NebulaDB with the Deno KV adapter for persistent edge storage in the Deno runtime.
+
+> **Note:** This example requires [Deno](https://deno.com/) and cannot be run with Node.js. Deno KV is a built-in key-value store available in Deno runtime and Deno Deploy.
+
+## Features Demonstrated
+
+1. **Deno KV Storage** - Using Deno's built-in key-value store for persistence
+2. **CRUD Operations** - Insert, find, update, and delete documents
+3. **Filtered Queries** - Query by field values
+4. **TypeScript Native** - No compilation step needed, Deno runs TypeScript directly
+5. **Connection Cleanup** - Properly closing the KV store after use
+
+## Requirements
+
+- [Deno](https://deno.com/) v1.38 or higher (for `--unstable-kv` support)
+
+## Setup
+
+### Install Deno
+
+```bash
+# macOS / Linux
+curl -fsSL https://deno.land/install.sh | sh
+
+# macOS with Homebrew
+brew install deno
+
+# Windows
+irm https://deno.land/install.ps1 | iex
+```
+
+Verify installation:
+
+```bash
+deno --version
+```
+
+## Running the Demo
+
+```bash
+cd examples/deno-kv-demo
+deno task start
+```
+
+Or directly:
+
+```bash
+deno run --unstable-kv main.ts
+```
+
+## Code Explanation
+
+### Adapter Setup
+
+```typescript
+const adapter = createDenoKvAdapter();
+const db = createDb({ adapter });
+```
+
+No connection string needed — Deno KV opens the default local store automatically.
+
+### Collection with Schema
+
+```typescript
+const notes = db.collection('notes', {
+  schema: {
+    title: { type: 'string' },
+    content: { type: 'string' },
+    pinned: { type: 'boolean' }
+  }
+});
+```
+
+### Filtered Query
+
+```typescript
+const pinned = await notes.find({ pinned: true });
+```
+
+### Always Close the Store
+
+```typescript
+await adapter.close();
+```
+
+## How Deno KV Storage Works
+
+Each document is stored as a separate KV entry with a structured key:
+
+```
+[prefix, collectionName, documentId] → JSON object
+```
+
+For example:
+```
+["nebula-db", "notes", "abc123"] → { title: "Welcome", pinned: true }
+```
+
+## Deno Deploy
+
+This example also works on [Deno Deploy](https://deno.com/deploy) — Cloudflare's edge alternative. Deno KV is available natively in the cloud environment with zero config.
+
+## Expected Output
+
+```
+=== NebulaDB Deno KV Adapter Demo ===
+ℹ️  Using Deno KV for persistent edge storage
+--------------------------------------------------
+
+=== Inserting Data ===
+✅ 3 notes inserted
+
+=== Querying All Records ===
+✅ Found 3 notes: [...]
+
+=== Filtered Query ===
+✅ Found 1 pinned notes: [...]
+
+=== Updating Data ===
+✅ Note updated: [...]
+
+=== Deleting Data ===
+✅ 2 notes remaining
+--------------------------------------------------
+✅ All operations completed successfully!
+```
+
+## Next Steps
+
+- Try the [Cloudflare D1 demo](../cloudflare-d1-demo) for another edge storage option
+- Deploy to [Deno Deploy](https://deno.com/deploy) for serverless edge hosting
+- Explore the [NebulaDB docs](https://github.com/Nom-nom-hub/NebulaDB)

--- a/examples/deno-kv-demo/deno.json
+++ b/examples/deno-kv-demo/deno.json
@@ -1,0 +1,9 @@
+{
+  "imports": {
+    "@nebula-db/core": "npm:@nebula-db/core@^0.4.0",
+    "@nebula-db/adapter-deno-kv": "npm:@nebula-db/adapter-deno-kv@^0.4.1"
+  },
+  "tasks": {
+    "start": "deno run --unstable-kv main.ts"
+  }
+}

--- a/examples/deno-kv-demo/main.ts
+++ b/examples/deno-kv-demo/main.ts
@@ -1,0 +1,78 @@
+import { createDb } from '@nebula-db/core';
+import { createDenoKvAdapter } from '@nebula-db/adapter-deno-kv';
+
+const log = {
+  title: (text: string) => console.log(`\n=== ${text} ===`),
+  info: (text: string) => console.log(`ℹ️  ${text}`),
+  success: (text: string) => console.log(`✅ ${text}`),
+  error: (text: string) => console.log(`❌ ${text}`),
+  data: (obj: unknown) => console.log(JSON.stringify(obj, null, 2)),
+  divider: () => console.log('-'.repeat(50))
+};
+
+const adapter = createDenoKvAdapter();
+const db = createDb({ adapter });
+
+const notes = db.collection('notes', {
+  schema: {
+    id: { type: 'string', optional: true },
+    title: { type: 'string' },
+    content: { type: 'string' },
+    pinned: { type: 'boolean' }
+  }
+});
+
+async function run() {
+  try {
+    log.title('NebulaDB Deno KV Adapter Demo');
+    log.info('Using Deno KV for persistent edge storage');
+    log.divider();
+
+    // Insert
+    log.title('Inserting Data');
+    await notes.insert({ title: 'Welcome', content: 'Hello from NebulaDB!', pinned: true });
+    await notes.insert({ title: 'Shopping List', content: 'Milk, Eggs, Bread', pinned: false });
+    await notes.insert({ title: 'Ideas', content: 'Build something cool', pinned: false });
+    log.success('3 notes inserted');
+
+    // Find all
+    log.title('Querying All Records');
+    const all = await notes.find();
+    log.success(`Found ${all.length} notes:`);
+    log.data(all);
+
+    // Filtered query
+    log.title('Filtered Query');
+    log.info('Finding pinned notes...');
+    const pinned = await notes.find({ pinned: true });
+    log.success(`Found ${pinned.length} pinned notes:`);
+    log.data(pinned);
+
+    // Update
+    log.title('Updating Data');
+    log.info('Pinning Shopping List...');
+    await notes.update({ title: 'Shopping List' }, { $set: { pinned: true } });
+    const updated = await notes.findOne({ title: 'Shopping List' });
+    log.success('Note updated:');
+    log.data(updated);
+
+    // Delete
+    log.title('Deleting Data');
+    log.info('Removing unpinned notes...');
+    await notes.delete({ pinned: false });
+    const remaining = await notes.find();
+    log.success(`${remaining.length} notes remaining:`);
+    log.data(remaining);
+
+    log.divider();
+    log.success('All operations completed successfully!');
+
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    log.error(`Demo failed: ${msg}`);
+  } finally {
+    await adapter.close();
+  }
+}
+
+run();

--- a/examples/mongodb-demo/README.md
+++ b/examples/mongodb-demo/README.md
@@ -1,0 +1,123 @@
+# NebulaDB MongoDB Adapter Demo
+
+This example demonstrates using NebulaDB with the MongoDB adapter for document-oriented persistent storage.
+
+## Features Demonstrated
+
+1. **MongoDB Connection** - Connecting via URI and database name
+2. **CRUD Operations** - Insert, find, update, and delete documents
+3. **Filtered Queries** - Query by multiple fields simultaneously
+4. **Auto Collection Creation** - Collections are created automatically on first save
+5. **Connection Cleanup** - Properly closing the client after use
+
+## Requirements
+
+- Node.js v18 or higher
+- A running MongoDB instance (local or remote)
+
+## Setup
+
+### Option A — Local MongoDB
+
+```bash
+# macOS
+brew install mongodb-community
+brew services start mongodb-community
+```
+
+### Option B — Docker
+
+```bash
+docker run --name nebula-mongo \
+  -p 27017:27017 \
+  -d mongo
+```
+
+### Option C — MongoDB Atlas (Cloud)
+
+Create a free cluster at https://www.mongodb.com/atlas and copy your connection string.
+
+## Installation
+
+```bash
+cd examples/mongodb-demo
+npm install
+```
+
+## Running the Demo
+
+```bash
+# Default: connects to mongodb://localhost:27017, database: nebuladb
+npm start
+
+# Custom connection
+MONGODB_URI=mongodb+srv://user:pass@cluster.mongodb.net MONGODB_DB=mydb npm start
+```
+
+## Code Explanation
+
+### Adapter Setup
+
+```javascript
+const adapter = createMongoDBAdapter({
+  uri: process.env.MONGODB_URI || 'mongodb://localhost:27017',
+  database: process.env.MONGODB_DB || 'nebuladb'
+});
+const db = createDatabase({ adapter });
+```
+
+### Collection with Schema
+
+```javascript
+const products = db.collection('products', {
+  schema: {
+    name: { type: 'string' },
+    category: { type: 'string' },
+    price: { type: 'number' },
+    inStock: { type: 'boolean' }
+  }
+});
+```
+
+### Filtered Query
+
+```javascript
+const available = await products.find({ category: 'Electronics', inStock: true });
+```
+
+### Always Close the Client
+
+```javascript
+await adapter.close();
+```
+
+## Expected Output
+
+```
+=== NebulaDB MongoDB Adapter Demo ===
+ℹ️  Connecting to MongoDB and demonstrating CRUD operations
+--------------------------------------------------
+
+=== Inserting Data ===
+✅ 3 products inserted
+
+=== Querying All Records ===
+✅ Found 3 products: [...]
+
+=== Filtered Query ===
+✅ Found 1 Electronics in stock: [...]
+
+=== Updating Data ===
+✅ Monitor updated: [...]
+
+=== Deleting Data ===
+✅ 2 products remaining
+--------------------------------------------------
+✅ All operations completed successfully!
+```
+
+## Next Steps
+
+- Try the [PostgreSQL demo](../postgresql-demo) for relational storage
+- Try the [Redis demo](../redis-demo) for cache-style storage
+- Explore the [NebulaDB docs](https://github.com/Nom-nom-hub/NebulaDB)

--- a/examples/mongodb-demo/index.js
+++ b/examples/mongodb-demo/index.js
@@ -1,0 +1,86 @@
+import pkg1 from '@nebula-db/nebula-db';
+const { createDatabase } = pkg1;
+
+import { createMongoDBAdapter } from '@nebula-db/adapter-mongodb';
+import chalk from 'chalk';
+
+const log = {
+  title: (text) => console.log(chalk.bold.blue(`\n=== ${text} ===`)),
+  info: (text) => console.log(chalk.cyan(`ℹ️  ${text}`)),
+  success: (text) => console.log(chalk.green(`✅ ${text}`)),
+  error: (text) => console.log(chalk.red(`❌ ${text}`)),
+  data: (obj) => console.log(chalk.gray(JSON.stringify(obj, null, 2))),
+  divider: () => console.log(chalk.gray('-'.repeat(50)))
+};
+
+const adapter = createMongoDBAdapter({
+  uri: process.env.MONGODB_URI || 'mongodb://localhost:27017',
+  database: process.env.MONGODB_DB || 'nebuladb'
+});
+
+const db = createDatabase({ adapter });
+
+const products = db.collection('products', {
+  schema: {
+    id: { type: 'string', optional: true },
+    name: { type: 'string' },
+    category: { type: 'string' },
+    price: { type: 'number' },
+    inStock: { type: 'boolean' }
+  }
+});
+
+async function run() {
+  try {
+    log.title('NebulaDB MongoDB Adapter Demo');
+    log.info('Connecting to MongoDB and demonstrating CRUD operations');
+    log.divider();
+
+    // Insert
+    log.title('Inserting Data');
+    await products.insert({ name: 'Laptop', category: 'Electronics', price: 1299, inStock: true });
+    await products.insert({ name: 'Desk Chair', category: 'Furniture', price: 349, inStock: true });
+    await products.insert({ name: 'Monitor', category: 'Electronics', price: 499, inStock: false });
+    log.success('3 products inserted');
+
+    // Find all
+    log.title('Querying All Records');
+    const all = await products.find();
+    log.success(`Found ${all.length} products:`);
+    log.data(all);
+
+    // Filtered query
+    log.title('Filtered Query');
+    log.info('Finding Electronics in stock...');
+    const available = await products.find({ category: 'Electronics', inStock: true });
+    log.success(`Found ${available.length} Electronics in stock:`);
+    log.data(available);
+
+    // Update
+    log.title('Updating Data');
+    log.info('Restocking Monitor...');
+    await products.update({ name: 'Monitor' }, { $set: { inStock: true } });
+    const monitor = await products.findOne({ name: 'Monitor' });
+    log.success('Monitor updated:');
+    log.data(monitor);
+
+    // Delete
+    log.title('Deleting Data');
+    log.info('Removing Furniture category...');
+    await products.delete({ category: 'Furniture' });
+    const remaining = await products.find();
+    log.success(`${remaining.length} products remaining:`);
+    log.data(remaining);
+
+    log.divider();
+    log.success('All operations completed successfully!');
+
+  } catch (error) {
+    log.error(`Demo failed: ${error.message}`);
+    console.error(error);
+  } finally {
+    await adapter.close();
+  }
+}
+
+run();

--- a/examples/mongodb-demo/package.json
+++ b/examples/mongodb-demo/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "nebula-mongodb-demo",
+  "version": "0.1.0",
+  "description": "MongoDB adapter demo for NebulaDB",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@nebula-db/nebula-db": "^0.4.0",
+    "@nebula-db/adapter-mongodb": "^0.4.1"
+  },
+  "devDependencies": {
+    "chalk": "^5.3.0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/examples/mysql-demo/README.md
+++ b/examples/mysql-demo/README.md
@@ -1,0 +1,125 @@
+# NebulaDB MySQL Adapter Demo
+
+This example demonstrates using NebulaDB with the MySQL adapter for persistent, relational storage.
+
+## Features Demonstrated
+
+1. **MySQL Connection** - Connecting via host, port, user, password, and database options
+2. **CRUD Operations** - Insert, find, update, and delete documents
+3. **Filtered Queries** - Query by field values
+4. **Auto Table Creation** - Tables are created automatically on first save
+5. **Connection Cleanup** - Properly closing the connection pool after use
+
+## Requirements
+
+- Node.js v18 or higher
+- A running MySQL instance (local or remote)
+
+## Setup
+
+### Option A — Local MySQL
+
+```bash
+# macOS
+brew install mysql
+brew services start mysql
+mysql -u root -e "CREATE DATABASE IF NOT EXISTS nebuladb;"
+```
+
+### Option B — Docker
+
+```bash
+docker run --name nebula-mysql \
+  -e MYSQL_ROOT_PASSWORD=password \
+  -e MYSQL_DATABASE=nebuladb \
+  -p 3306:3306 \
+  -d mysql
+```
+
+## Installation
+
+```bash
+cd examples/mysql-demo
+npm install
+```
+
+## Running the Demo
+
+```bash
+# Default: connects to localhost:3306, user: root, database: nebuladb
+npm start
+
+# Custom connection
+MYSQL_HOST=localhost MYSQL_USER=myuser MYSQL_PASSWORD=mypass MYSQL_DB=mydb npm start
+```
+
+## Code Explanation
+
+### Adapter Setup
+
+```javascript
+const adapter = createMySQLAdapter({
+  host: process.env.MYSQL_HOST || 'localhost',
+  port: parseInt(process.env.MYSQL_PORT || '3306'),
+  user: process.env.MYSQL_USER || 'root',
+  password: process.env.MYSQL_PASSWORD || '',
+  database: process.env.MYSQL_DB || 'nebuladb'
+});
+const db = createDatabase({ adapter });
+```
+
+### Collection with Schema
+
+```javascript
+const orders = db.collection('orders', {
+  schema: {
+    customer: { type: 'string' },
+    product: { type: 'string' },
+    quantity: { type: 'number' },
+    fulfilled: { type: 'boolean' }
+  }
+});
+```
+
+### Filtered Query
+
+```javascript
+const pending = await orders.find({ fulfilled: false });
+```
+
+### Always Close the Pool
+
+```javascript
+await adapter.close();
+```
+
+## Expected Output
+
+```
+=== NebulaDB MySQL Adapter Demo ===
+ℹ️  Connecting to MySQL and demonstrating CRUD operations
+--------------------------------------------------
+
+=== Inserting Data ===
+✅ 3 orders inserted
+
+=== Querying All Records ===
+✅ Found 3 orders: [...]
+
+=== Filtered Query ===
+✅ Found 2 pending orders: [...]
+
+=== Updating Data ===
+✅ Order updated: [...]
+
+=== Deleting Data ===
+✅ 1 orders remaining
+--------------------------------------------------
+✅ All operations completed successfully!
+```
+
+## Next Steps
+
+- Try the [PostgreSQL demo](../postgresql-demo) for another SQL option
+- Try the [MongoDB demo](../mongodb-demo) for document-oriented storage
+- Explore the [NebulaDB docs](https://github.com/Nom-nom-hub/NebulaDB)

--- a/examples/mysql-demo/index.js
+++ b/examples/mysql-demo/index.js
@@ -1,0 +1,89 @@
+import pkg1 from '@nebula-db/nebula-db';
+const { createDatabase } = pkg1;
+
+import { createMySQLAdapter } from '@nebula-db/adapter-mysql';
+import chalk from 'chalk';
+
+const log = {
+  title: (text) => console.log(chalk.bold.blue(`\n=== ${text} ===`)),
+  info: (text) => console.log(chalk.cyan(`ℹ️  ${text}`)),
+  success: (text) => console.log(chalk.green(`✅ ${text}`)),
+  error: (text) => console.log(chalk.red(`❌ ${text}`)),
+  data: (obj) => console.log(chalk.gray(JSON.stringify(obj, null, 2))),
+  divider: () => console.log(chalk.gray('-'.repeat(50)))
+};
+
+const adapter = createMySQLAdapter({
+  host: process.env.MYSQL_HOST || 'localhost',
+  port: parseInt(process.env.MYSQL_PORT || '3306'),
+  user: process.env.MYSQL_USER || 'root',
+  password: process.env.MYSQL_PASSWORD || '',
+  database: process.env.MYSQL_DB || 'nebuladb'
+});
+
+const db = createDatabase({ adapter });
+
+const orders = db.collection('orders', {
+  schema: {
+    id: { type: 'string', optional: true },
+    customer: { type: 'string' },
+    product: { type: 'string' },
+    quantity: { type: 'number' },
+    fulfilled: { type: 'boolean' }
+  }
+});
+
+async function run() {
+  try {
+    log.title('NebulaDB MySQL Adapter Demo');
+    log.info('Connecting to MySQL and demonstrating CRUD operations');
+    log.divider();
+
+    // Insert
+    log.title('Inserting Data');
+    await orders.insert({ customer: 'Alice', product: 'Laptop', quantity: 1, fulfilled: false });
+    await orders.insert({ customer: 'Bob', product: 'Mouse', quantity: 2, fulfilled: true });
+    await orders.insert({ customer: 'Carol', product: 'Keyboard', quantity: 1, fulfilled: false });
+    log.success('3 orders inserted');
+
+    // Find all
+    log.title('Querying All Records');
+    const all = await orders.find();
+    log.success(`Found ${all.length} orders:`);
+    log.data(all);
+
+    // Filtered query
+    log.title('Filtered Query');
+    log.info('Finding unfulfilled orders...');
+    const pending = await orders.find({ fulfilled: false });
+    log.success(`Found ${pending.length} pending orders:`);
+    log.data(pending);
+
+    // Update
+    log.title('Updating Data');
+    log.info('Fulfilling Alice\'s order...');
+    await orders.update({ customer: 'Alice' }, { $set: { fulfilled: true } });
+    const alice = await orders.findOne({ customer: 'Alice' });
+    log.success('Order updated:');
+    log.data(alice);
+
+    // Delete
+    log.title('Deleting Data');
+    log.info('Removing fulfilled orders...');
+    await orders.delete({ fulfilled: true });
+    const remaining = await orders.find();
+    log.success(`${remaining.length} orders remaining:`);
+    log.data(remaining);
+
+    log.divider();
+    log.success('All operations completed successfully!');
+
+  } catch (error) {
+    log.error(`Demo failed: ${error.message}`);
+    console.error(error);
+  } finally {
+    await adapter.close();
+  }
+}
+
+run();

--- a/examples/mysql-demo/package.json
+++ b/examples/mysql-demo/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "nebula-mysql-demo",
+  "version": "0.1.0",
+  "description": "MySQL adapter demo for NebulaDB",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@nebula-db/nebula-db": "^0.4.0",
+    "@nebula-db/adapter-mysql": "^0.4.1"
+  },
+  "devDependencies": {
+    "chalk": "^5.3.0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/examples/postgresql-demo/README.md
+++ b/examples/postgresql-demo/README.md
@@ -1,0 +1,121 @@
+# NebulaDB PostgreSQL Adapter Demo
+
+This example demonstrates using NebulaDB with the PostgreSQL adapter for persistent, server-side storage.
+
+## Features Demonstrated
+
+1. **PostgreSQL Connection** - Connecting via connection string or `DATABASE_URL` env var
+2. **CRUD Operations** - Insert, find, update, and delete documents
+3. **Filtered Queries** - Query by multiple fields simultaneously
+4. **Auto Table Creation** - Adapter creates tables automatically on first save
+5. **Connection Cleanup** - Properly closing the connection pool after use
+
+## Requirements
+
+- Node.js v18 or higher
+- A running PostgreSQL instance (local or remote)
+
+## Setup
+
+### Option A — Local PostgreSQL
+
+```bash
+# macOS
+brew install postgresql
+brew services start postgresql
+createdb nebuladb
+```
+
+### Option B — Docker
+
+```bash
+docker run --name nebula-postgres \
+  -e POSTGRES_DB=nebuladb \
+  -e POSTGRES_PASSWORD=password \
+  -p 5432:5432 \
+  -d postgres
+```
+
+## Installation
+
+```bash
+cd examples/postgresql-demo
+npm install
+```
+
+## Running the Demo
+
+```bash
+# Default: connects to postgres://localhost:5432/nebuladb
+npm start
+
+# Custom connection
+DATABASE_URL=postgres://user:password@localhost:5432/mydb npm start
+```
+
+## Code Explanation
+
+### Adapter Setup
+
+```javascript
+const adapter = createPostgreSQLAdapter(
+  process.env.DATABASE_URL || 'postgres://localhost:5432/nebuladb'
+);
+const db = createDatabase({ adapter });
+```
+
+### Collection with Schema
+
+```javascript
+const employees = db.collection('employees', {
+  schema: {
+    name: { type: 'string' },
+    department: { type: 'string' },
+    salary: { type: 'number' },
+    active: { type: 'boolean' }
+  }
+});
+```
+
+### Filtered Query
+
+```javascript
+const engineers = await employees.find({ department: 'Engineering', active: true });
+```
+
+### Always Close the Pool
+
+```javascript
+await adapter.close();
+```
+
+## Expected Output
+
+```
+=== NebulaDB PostgreSQL Adapter Demo ===
+ℹ️  Connecting to PostgreSQL and demonstrating CRUD operations
+--------------------------------------------------
+
+=== Inserting Data ===
+✅ 3 employees inserted
+
+=== Querying All Records ===
+✅ Found 3 employees: [...]
+
+=== Filtered Query ===
+✅ Found 1 active engineers: [...]
+
+=== Updating Data ===
+✅ Bob updated: [...]
+
+=== Deleting Data ===
+✅ 2 employees remaining after deletion
+--------------------------------------------------
+✅ All operations completed successfully!
+```
+
+## Next Steps
+
+- Try the [MongoDB demo](../mongodb-demo) for document-oriented storage
+- Try the [Redis demo](../redis-demo) for cache-style storage
+- Explore the [NebulaDB docs](https://github.com/Nom-nom-hub/NebulaDB)

--- a/examples/postgresql-demo/index.js
+++ b/examples/postgresql-demo/index.js
@@ -1,0 +1,87 @@
+import pkg1 from '@nebula-db/nebula-db';
+const { createDatabase } = pkg1;
+
+import { createPostgreSQLAdapter } from '@nebula-db/adapter-postgresql';
+import chalk from 'chalk';
+
+// Console styling functions (matching repo style)
+const log = {
+  title: (text) => console.log(chalk.bold.blue(`\n=== ${text} ===`)),
+  info: (text) => console.log(chalk.cyan(`ℹ️  ${text}`)),
+  success: (text) => console.log(chalk.green(`✅ ${text}`)),
+  error: (text) => console.log(chalk.red(`❌ ${text}`)),
+  data: (obj) => console.log(chalk.gray(JSON.stringify(obj, null, 2))),
+  divider: () => console.log(chalk.gray('-'.repeat(50)))
+};
+
+// Create adapter — reads DATABASE_URL env var or falls back to default
+const adapter = createPostgreSQLAdapter(
+  process.env.DATABASE_URL || 'postgres://localhost:5432/nebuladb'
+);
+
+const db = createDatabase({ adapter });
+
+const employees = db.collection('employees', {
+  schema: {
+    id: { type: 'string', optional: true },
+    name: { type: 'string' },
+    department: { type: 'string' },
+    salary: { type: 'number' },
+    active: { type: 'boolean' }
+  }
+});
+
+async function run() {
+  try {
+    log.title('NebulaDB PostgreSQL Adapter Demo');
+    log.info('Connecting to PostgreSQL and demonstrating CRUD operations');
+    log.divider();
+
+    // Insert
+    log.title('Inserting Data');
+    await employees.insert({ name: 'Alice', department: 'Engineering', salary: 95000, active: true });
+    await employees.insert({ name: 'Bob', department: 'Marketing', salary: 72000, active: true });
+    await employees.insert({ name: 'Carol', department: 'Engineering', salary: 105000, active: false });
+    log.success('3 employees inserted');
+
+    // Find all
+    log.title('Querying All Records');
+    const all = await employees.find();
+    log.success(`Found ${all.length} employees:`);
+    log.data(all);
+
+    // Filtered query
+    log.title('Filtered Query');
+    log.info('Finding active Engineering employees...');
+    const engineers = await employees.find({ department: 'Engineering', active: true });
+    log.success(`Found ${engineers.length} active engineers:`);
+    log.data(engineers);
+
+    // Update
+    log.title('Updating Data');
+    log.info('Giving Bob a raise...');
+    await employees.update({ name: 'Bob' }, { $set: { salary: 80000 } });
+    const bob = await employees.findOne({ name: 'Bob' });
+    log.success('Bob updated:');
+    log.data(bob);
+
+    // Delete
+    log.title('Deleting Data');
+    log.info('Removing inactive employees...');
+    await employees.delete({ active: false });
+    const remaining = await employees.find();
+    log.success(`${remaining.length} employees remaining after deletion`);
+    log.data(remaining);
+
+    log.divider();
+    log.success('All operations completed successfully!');
+
+  } catch (error) {
+    log.error(`Demo failed: ${error.message}`);
+    console.error(error);
+  } finally {
+    await adapter.close();
+  }
+}
+
+run();

--- a/examples/postgresql-demo/package.json
+++ b/examples/postgresql-demo/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "nebula-postgresql-demo",
+  "version": "0.1.0",
+  "description": "PostgreSQL adapter demo for NebulaDB",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@nebula-db/nebula-db": "^0.4.0",
+    "@nebula-db/adapter-postgresql": "^0.4.1"
+  },
+  "devDependencies": {
+    "chalk": "^5.3.0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/examples/redis-demo/README.md
+++ b/examples/redis-demo/README.md
@@ -1,0 +1,134 @@
+# NebulaDB Redis Adapter Demo
+
+This example demonstrates using NebulaDB with the Redis adapter for fast, in-memory persistent storage. Redis is ideal for session management, caching, and real-time data.
+
+## Features Demonstrated
+
+1. **Redis Connection** - Connecting via URL or options object
+2. **CRUD Operations** - Insert, find, update, and delete documents
+3. **Filtered Queries** - Query by field values
+4. **Key Prefixing** - Documents stored under `nebula-db:{collection}:{id}` keys
+5. **Connection Cleanup** - Properly closing the Redis connection after use
+
+## Requirements
+
+- Node.js v18 or higher
+- A running Redis instance (local or remote)
+
+## Setup
+
+### Option A — Local Redis
+
+```bash
+# macOS
+brew install redis
+brew services start redis
+```
+
+### Option B — Docker
+
+```bash
+docker run --name nebula-redis \
+  -p 6379:6379 \
+  -d redis
+```
+
+### Option C — Redis Cloud
+
+Create a free instance at https://redis.io/try-free and copy your connection URL.
+
+## Installation
+
+```bash
+cd examples/redis-demo
+npm install
+```
+
+## Running the Demo
+
+```bash
+# Default: connects to redis://localhost:6379
+npm start
+
+# Custom connection
+REDIS_URL=redis://user:password@your-host:6379 npm start
+```
+
+## Code Explanation
+
+### Adapter Setup
+
+```javascript
+const adapter = createRedisAdapter(
+  process.env.REDIS_URL || 'redis://localhost:6379'
+);
+const db = createDatabase({ adapter });
+```
+
+### Collection with Schema
+
+```javascript
+const sessions = db.collection('sessions', {
+  schema: {
+    userId: { type: 'string' },
+    token: { type: 'string' },
+    active: { type: 'boolean' }
+  }
+});
+```
+
+### Filtered Query
+
+```javascript
+const active = await sessions.find({ active: true });
+```
+
+### Always Close the Connection
+
+```javascript
+await adapter.close();
+```
+
+## How Redis Storage Works
+
+Each document is stored as a separate Redis key in the format:
+
+```
+nebula-db:{collection}:{documentId} → JSON string
+```
+
+For example:
+```
+nebula-db:sessions:abc123 → {"userId":"user_1","token":"tok_abc123","active":true}
+```
+
+## Expected Output
+
+```
+=== NebulaDB Redis Adapter Demo ===
+ℹ️  Connecting to Redis and demonstrating CRUD operations
+--------------------------------------------------
+
+=== Inserting Data ===
+✅ 3 sessions inserted
+
+=== Querying All Records ===
+✅ Found 3 sessions: [...]
+
+=== Filtered Query ===
+✅ Found 2 active sessions: [...]
+
+=== Updating Data ===
+✅ Session updated: [...]
+
+=== Deleting Data ===
+✅ 1 sessions remaining
+--------------------------------------------------
+✅ All operations completed successfully!
+```
+
+## Next Steps
+
+- Try the [PostgreSQL demo](../postgresql-demo) for relational storage
+- Try the [MongoDB demo](../mongodb-demo) for document-oriented storage
+- Explore the [NebulaDB docs](https://github.com/Nom-nom-hub/NebulaDB)

--- a/examples/redis-demo/index.js
+++ b/examples/redis-demo/index.js
@@ -1,0 +1,84 @@
+import pkg1 from '@nebula-db/nebula-db';
+const { createDatabase } = pkg1;
+
+import { createRedisAdapter } from '@nebula-db/adapter-redis';
+import chalk from 'chalk';
+
+const log = {
+  title: (text) => console.log(chalk.bold.blue(`\n=== ${text} ===`)),
+  info: (text) => console.log(chalk.cyan(`ℹ️  ${text}`)),
+  success: (text) => console.log(chalk.green(`✅ ${text}`)),
+  error: (text) => console.log(chalk.red(`❌ ${text}`)),
+  data: (obj) => console.log(chalk.gray(JSON.stringify(obj, null, 2))),
+  divider: () => console.log(chalk.gray('-'.repeat(50)))
+};
+
+const adapter = createRedisAdapter(
+  process.env.REDIS_URL || 'redis://localhost:6379'
+);
+
+const db = createDatabase({ adapter });
+
+const sessions = db.collection('sessions', {
+  schema: {
+    id: { type: 'string', optional: true },
+    userId: { type: 'string' },
+    token: { type: 'string' },
+    active: { type: 'boolean' }
+  }
+});
+
+async function run() {
+  try {
+    log.title('NebulaDB Redis Adapter Demo');
+    log.info('Connecting to Redis and demonstrating CRUD operations');
+    log.divider();
+
+    // Insert
+    log.title('Inserting Data');
+    await sessions.insert({ userId: 'user_1', token: 'tok_abc123', active: true });
+    await sessions.insert({ userId: 'user_2', token: 'tok_def456', active: true });
+    await sessions.insert({ userId: 'user_3', token: 'tok_ghi789', active: false });
+    log.success('3 sessions inserted');
+
+    // Find all
+    log.title('Querying All Records');
+    const all = await sessions.find();
+    log.success(`Found ${all.length} sessions:`);
+    log.data(all);
+
+    // Filtered query
+    log.title('Filtered Query');
+    log.info('Finding active sessions...');
+    const active = await sessions.find({ active: true });
+    log.success(`Found ${active.length} active sessions:`);
+    log.data(active);
+
+    // Update
+    log.title('Updating Data');
+    log.info('Deactivating user_2 session...');
+    await sessions.update({ userId: 'user_2' }, { $set: { active: false } });
+    const user2 = await sessions.findOne({ userId: 'user_2' });
+    log.success('Session updated:');
+    log.data(user2);
+
+    // Delete
+    log.title('Deleting Data');
+    log.info('Removing inactive sessions...');
+    await sessions.delete({ active: false });
+    const remaining = await sessions.find();
+    log.success(`${remaining.length} sessions remaining:`);
+    log.data(remaining);
+
+    log.divider();
+    log.success('All operations completed successfully!');
+
+  } catch (error) {
+    log.error(`Demo failed: ${error.message}`);
+    console.error(error);
+  } finally {
+    await adapter.close();
+  }
+}
+
+run();

--- a/examples/redis-demo/package.json
+++ b/examples/redis-demo/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "nebula-redis-demo",
+  "version": "0.1.0",
+  "description": "Redis adapter demo for NebulaDB",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@nebula-db/nebula-db": "^0.4.0",
+    "@nebula-db/adapter-redis": "^0.4.1"
+  },
+  "devDependencies": {
+    "chalk": "^5.3.0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
Closes #30

## What this PR adds

Six new working examples for the adapter packages requested in issue #30:

- `examples/postgresql-demo` — CRUD demo using PostgreSQL adapter
- `examples/mongodb-demo` — CRUD demo using MongoDB adapter  
- `examples/mysql-demo` — CRUD demo using MySQL adapter
- `examples/redis-demo` — CRUD demo using Redis adapter
- `examples/cloudflare-d1-demo` — Worker-based demo using Cloudflare D1 adapter
- `examples/deno-kv-demo` — TypeScript demo using Deno KV adapter

## Structure

Each example follows the existing `node-demo` pattern:
- `index.js` / `main.ts` — working demo with chalk-styled output
- `package.json` / `deno.json` — dependencies and run script
- `README.md` — setup instructions, code explanation, expected output

## Notes

- Cloudflare D1 and Deno KV examples use their respective runtimes (Wrangler and Deno) since they cannot run in Node.js
- All examples read config from environment variables with sensible local defaults

## Summary by Sourcery

Add a suite of runnable examples demonstrating NebulaDB adapters for common databases and edge runtimes, each showcasing basic CRUD flows and environment-based configuration.

New Features:
- Introduce PostgreSQL example app with CLI-style CRUD demo, schema definition, and npm script for running against a configurable DATABASE_URL.
- Introduce MongoDB example app demonstrating document-style CRUD operations with configurable URI and database via environment variables.
- Introduce MySQL example app showcasing relational CRUD operations with connection details sourced from environment variables.
- Introduce Redis example app illustrating session-style CRUD operations over a configurable Redis URL with key-based storage semantics.
- Introduce Cloudflare D1 Worker example exposing HTTP routes that exercise CRUD operations against a D1-backed NebulaDB collection.
- Introduce Deno KV TypeScript example demonstrating NebulaDB usage in the Deno runtime with KV-based persistence and task-style logging output.

Build:
- Add runtime-specific config files (package.json, deno.json, wrangler.toml) to wire up dependencies and scripts for each new example.

Documentation:
- Add README guides for PostgreSQL, MongoDB, MySQL, Redis, Cloudflare D1, and Deno KV examples covering setup, running instructions, and expected output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added six new demo examples for database adapters: Cloudflare D1, Deno KV, MongoDB, MySQL, PostgreSQL, and Redis.

* **Documentation**
  * Added comprehensive README guides for each example with setup instructions, prerequisites, features overview, and expected output.

* **Chores**
  * Added configuration files and package dependencies for each example project.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nom-nom-hub/NebulaDB/pull/36)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->