### PR TITLE
test(adapter-vercel-kv): add fetch-backed coverage

### DIFF
--- a/packages/adapter-vercel-kv/src/index.ts
+++ b/packages/adapter-vercel-kv/src/index.ts
@@ -92,12 +92,8 @@ export class VercelKvAdapter implements Adapter {
       for (const { key } of keys) {
         if (!key.startsWith(this.namespacePrefix)) continue;
         
-        // Parse collection name from key
-        // Format: nebula_{collection}
-        const match = key.match(/^nebula_(.+)$/);
-        if (!match) continue;
-        
-        const collectionName = match[1];
+        const collectionName = key.slice(this.namespacePrefix.length);
+        if (!collectionName) continue;
         
         try {
           const result = await this.request<{ data: string }>(`/get/${key}`);

--- a/packages/adapter-vercel-kv/tests/adapter-vercel-kv.test.ts
+++ b/packages/adapter-vercel-kv/tests/adapter-vercel-kv.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Document } from '@nebula-db/core';
+import { VercelKvAdapter, createVercelKvAdapter } from '../src/index';
+
+const API_URL = 'https://kv.example.com';
+const API_TOKEN = 'test-token';
+
+type FetchCall = {
+  url: string;
+  init?: RequestInit;
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status >= 200 && status < 300 ? 'OK' : 'Error',
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'content-type' ? 'application/json' : null
+    },
+    json: vi.fn().mockResolvedValue(body)
+  } as unknown as Response;
+}
+
+function stubFetch(routes: Record<string, unknown>): FetchCall[] {
+  const calls: FetchCall[] = [];
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      const path = url.replace(API_URL, '');
+      if (!(path in routes)) {
+        return jsonResponse({ error: `unhandled route: ${path}` }, 404);
+      }
+
+      return jsonResponse(routes[path]);
+    })
+  );
+
+  return calls;
+}
+
+describe('VercelKvAdapter', () => {
+  beforeEach(() => {
+    stubFetch({ '/keys': [] });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should create an adapter from the factory', () => {
+    const adapter = createVercelKvAdapter(API_URL, API_TOKEN);
+
+    expect(adapter).toBeInstanceOf(VercelKvAdapter);
+  });
+
+  it('should require an API URL and token', () => {
+    expect(() => new VercelKvAdapter('', API_TOKEN)).toThrow(
+      'Vercel KV API URL and token are required'
+    );
+    expect(() => new VercelKvAdapter(API_URL, '')).toThrow(
+      'Vercel KV API URL and token are required'
+    );
+  });
+
+  it('should connect with Vercel KV authorization headers', async () => {
+    const calls = stubFetch({ '/keys': [] });
+    const adapter = createVercelKvAdapter(API_URL, API_TOKEN);
+
+    await adapter.connect();
+
+    expect(calls[0].url).toBe(`${API_URL}/keys`);
+    expect(calls[0].init?.headers).toMatchObject({
+      Authorization: `Bearer ${API_TOKEN}`,
+      'Content-Type': 'application/json'
+    });
+  });
+
+  it('should load namespaced collections from KV', async () => {
+    const users: Document[] = [{ id: '1', name: 'Alice' }];
+    stubFetch({
+      '/keys': [],
+      '/keys?limit=1000': [
+        { key: 'nebula_users' },
+        { key: 'other_collection' }
+      ],
+      '/get/nebula_users': { data: JSON.stringify(users) }
+    });
+    const adapter = createVercelKvAdapter(API_URL, API_TOKEN);
+
+    const data = await adapter.load();
+
+    expect(data).toEqual({ users });
+    expect(adapter.getData()).toEqual({ users });
+  });
+
+  it('should save each collection with the configured namespace', async () => {
+    const calls = stubFetch({ '/keys': [], '/set/app_users': undefined });
+    const adapter = createVercelKvAdapter(API_URL, API_TOKEN, {
+      namespacePrefix: 'app_'
+    });
+
+    await adapter.save({ users: [{ id: '1', name: 'Bob' }] });
+
+    const saveCall = calls.find(call => call.url === `${API_URL}/set/app_users`);
+    expect(saveCall?.init?.method).toBe('POST');
+    expect(JSON.parse(String(saveCall?.init?.body))).toEqual({
+      value: JSON.stringify([{ id: '1', name: 'Bob' }])
+    });
+  });
+
+  it('should get and set values through namespaced KV keys', async () => {
+    const calls = stubFetch({
+      '/keys': [],
+      '/set/nebula_profile': undefined,
+      '/get/nebula_profile': { data: JSON.stringify({ id: '1', active: true }) }
+    });
+    const adapter = createVercelKvAdapter(API_URL, API_TOKEN);
+
+    await adapter.set('profile', { id: '1', active: true });
+    const profile = await adapter.get('profile');
+
+    expect(profile).toEqual({ id: '1', active: true });
+    expect(calls.map(call => call.url)).toContain(`${API_URL}/set/nebula_profile`);
+    expect(calls.map(call => call.url)).toContain(`${API_URL}/get/nebula_profile`);
+  });
+
+  it('should delete namespaced KV keys', async () => {
+    const calls = stubFetch({ '/keys': [], '/del/nebula_profile': undefined });
+    const adapter = createVercelKvAdapter(API_URL, API_TOKEN);
+
+    await adapter.delete('profile');
+
+    const deleteCall = calls.find(
+      call => call.url === `${API_URL}/del/nebula_profile`
+    );
+    expect(deleteCall?.init?.method).toBe('DELETE');
+  });
+});

--- a/packages/adapter-vercel-kv/tests/adapter-vercel-kv.test.ts
+++ b/packages/adapter-vercel-kv/tests/adapter-vercel-kv.test.ts
@@ -97,6 +97,23 @@ describe('VercelKvAdapter', () => {
     expect(adapter.getData()).toEqual({ users });
   });
 
+  it('should load collections with a custom namespace prefix', async () => {
+    const users: Document[] = [{ id: '1', name: 'Alice' }];
+    stubFetch({
+      '/keys': [],
+      '/keys?limit=1000': [{ key: 'app_users' }],
+      '/get/app_users': { data: JSON.stringify(users) }
+    });
+    const adapter = createVercelKvAdapter(API_URL, API_TOKEN, {
+      namespacePrefix: 'app_'
+    });
+
+    const data = await adapter.load();
+
+    expect(data).toEqual({ users });
+    expect(adapter.getData()).toEqual({ users });
+  });
+
   it('should save each collection with the configured namespace', async () => {
     const calls = stubFetch({ '/keys': [], '/set/app_users': undefined });
     const adapter = createVercelKvAdapter(API_URL, API_TOKEN, {


### PR DESCRIPTION
Part of #42.

## Summary
- add a Vercel KV adapter test suite using a mocked `fetch` implementation
- cover factory creation, required credentials, connection headers, load, save, get/set, and delete behavior
- keep the suite local and deterministic without Vercel credentials or Redis/Docker services

## Validation
- `npx vitest run packages/adapter-vercel-kv/tests/adapter-vercel-kv.test.ts` passes
- `npm test -- --run` currently has unrelated existing failures in `packages/core/tests/sqlite-adapter.test.ts` (`SQLiteAdapter is not a constructor`)
- `npm run lint` currently has unrelated existing errors in `adapter-aws-lambda`, `plugin-audit`, and `plugin-streaming`

## Summary by Sourcery

Add a deterministic, fetch-mocked test suite for the Vercel KV adapter to validate its core behaviors without external KV or Redis services.

New Features:
- Introduce a local test harness for Vercel KV adapter interactions backed by a mocked fetch implementation.

Tests:
- Add coverage for VercelKvAdapter factory creation, required credentials, connection headers, load/save operations, get/set behavior, and key deletion using a mocked Vercel KV API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adapter now respects the configured namespace prefix when loading collections, avoiding incorrect or empty collection names.

* **Tests**
  * Added comprehensive tests for the Vercel KV adapter covering initialization, authorization headers, collection loading with namespaces, per-key save/get/delete operations, and collection-level listing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nom-nom-hub/NebulaDB/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->